### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To enable global scope for this connector, the code will need to go through revi
 
 ### Format
 
-Presently, we support the following types
+Presently, we support the following types:
   - JSON
   - XML
 

--- a/README.md
+++ b/README.md
@@ -48,10 +48,6 @@ To enable global scope for this connector, the code will need to go through revi
 
 ## Requirements
 
-### REST Architecture
-
-Presently, only RESTful APIs are supported by the Connector SDK.
-
 ### Format
 
 Presently, we support the following types


### PR DESCRIPTION
To remove the section saying -
> Presently, only RESTful APIs are supported by the Connector SDK.

As we support both REST and SOAP APIs in SDK.