### PR TITLE
Enable Successful Parsing of Date and Date/Time Responses

### DIFF
--- a/custom_connectors/custom_auth/sage_intacct_connector.rb
+++ b/custom_connectors/custom_auth/sage_intacct_connector.rb
@@ -75,6 +75,11 @@
                                      'array_fields' => array_fields)
                        }
                      end)
+        #regex for date detection TODO: Lazy duplicate conditionals
+        elsif key == 'content!' && value.match?(/^\d{1,2}\/\d{1,2}\/\d{4}$/)
+          value.to_date(format: '%m/%d/%Y')
+        elsif key == 'content!' && value.match?(/^\d{1,2}\/\d{1,2}\/\d{4} /)
+          value.to_time(format: '%m/%d/%Y %H:%M:%S')
         elsif key == 'content!'
           value
         else


### PR DESCRIPTION
Ran into this issue today and this is how I just fixed it. These date conversion failures would crop up when testing the employee endpoint and would fail as an invalid date or date time when attempting to parse the STARTDATE and MODIFIEDDATE response fields.

There is likely a better way to detect off of the `key.includes('DATE')` instead of the regex match, but I am no ruby expert.

Open to improvements, but I think this would be nice to have so others don't have to waste time on this.